### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ cd f5-journeys
 
 1. Fetch services included in the docker-compose configuration file
    ```
-   docker-compose pull
+   docker compose pull
    ```
 
 1. Print sha digest of downloaded images


### PR DESCRIPTION
remove hyphen from "docker-compose pull" to "docker compose pull", a syntax error.